### PR TITLE
add drug information into cda

### DIFF
--- a/PDMP-Demo/src/main/java/gov/hhs/fha/nhinc/pdmp/managed/PatientSearchBean.java
+++ b/PDMP-Demo/src/main/java/gov/hhs/fha/nhinc/pdmp/managed/PatientSearchBean.java
@@ -26,28 +26,28 @@
  */
 package gov.hhs.fha.nhinc.pdmp.managed;
 
-import gov.hhs.fha.nhinc.admingui.constant.NavigationConstant;
-import gov.hhs.fha.nhinc.pdmp.services.GatewayService;
-import gov.hhs.fha.nhinc.pdmp.model.Document;
-import gov.hhs.fha.nhinc.pdmp.model.Patient;
+import static gov.hhs.fha.nhinc.util.StreamUtils.closeStreamSilently;
+
 import gov.hhs.fha.nhinc.admingui.util.ConnectionHelper;
-import gov.hhs.fha.nhinc.pdmp.util.XSLTransformHelper;
 import gov.hhs.fha.nhinc.nhinclib.NhincConstants;
 import gov.hhs.fha.nhinc.nhinclib.NullChecker;
 import gov.hhs.fha.nhinc.pdmp.AddressRequiredZipType;
 import gov.hhs.fha.nhinc.pdmp.PatientType;
+import gov.hhs.fha.nhinc.pdmp.model.Document;
+import gov.hhs.fha.nhinc.pdmp.model.Patient;
 import gov.hhs.fha.nhinc.pdmp.model.PdmpPatient;
 import gov.hhs.fha.nhinc.pdmp.model.PrescriptionInfo;
 import gov.hhs.fha.nhinc.pdmp.services.CDAParserService;
 import gov.hhs.fha.nhinc.pdmp.services.CDAParserServiceImpl;
+import gov.hhs.fha.nhinc.pdmp.services.GatewayService;
 import gov.hhs.fha.nhinc.pdmp.services.PdmpService;
 import gov.hhs.fha.nhinc.pdmp.services.PdmpServiceImpl;
 import gov.hhs.fha.nhinc.pdmp.services.PrescriptionClassSearch;
 import gov.hhs.fha.nhinc.pdmp.services.PrescriptionClassSearchImpl;
 import gov.hhs.fha.nhinc.pdmp.util.HtmlParserUtil;
+import gov.hhs.fha.nhinc.pdmp.util.XSLTransformHelper;
 import gov.hhs.fha.nhinc.properties.PropertyAccessException;
 import gov.hhs.fha.nhinc.properties.PropertyAccessor;
-import static gov.hhs.fha.nhinc.util.StreamUtils.closeStreamSilently;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -227,7 +227,7 @@ public class PatientSearchBean {
                         drug.setDrugClass(drugClassService.searchForDrugClass(namePart));
                     }
                     if (NullChecker.isNotNullish(drug.getDrugClass())
-                            && drug.getDrugClass().toLowerCase().contains("opioid".toLowerCase())) {
+                        && drug.getDrugClass().toLowerCase().contains("opioid".toLowerCase())) {
                         drug.setIsOpioid(true);
                         opioidList.add(drug);
                     } else {
@@ -249,13 +249,14 @@ public class PatientSearchBean {
         String updatedDoc = cdaParser.addMedicationSection(stream, selectedDrugs);
         if (NullChecker.isNotNullish(updatedDoc)) {
             Document document = getDocumentList().get(getSelectedDocument());
-            document.setDocumentContent(convertXmlToHtml(updatedDoc.getBytes()));
+            document.setDocumentContent(updatedDoc.getBytes());
+            document.setHtmlContent(convertXmlToHtml(updatedDoc.getBytes()));
         }
     }
-    
+
     public byte[] convertXmlToHtml(byte[] originalDocument) {
         final InputStream xsl = FacesContext.getCurrentInstance().getExternalContext()
-                .getResourceAsStream(DEFAULT_XSL_FILE);
+            .getResourceAsStream(DEFAULT_XSL_FILE);
         final InputStream xml = new ByteArrayInputStream(originalDocument);
         byte[] convertXmlToHtml = null;
         if (xsl != null) {
@@ -460,7 +461,7 @@ public class PatientSearchBean {
         this.opioidsOnly = opioidsOnly;
     }
 
-    
+
     public void changeTableForOpioidValues() {
         if(opioidsOnly) {
             prescriptionList = opioidList;
@@ -687,7 +688,7 @@ public class PatientSearchBean {
         try {
             // Load the documentType.properties file
             Properties localDocumentTypeProperties = PropertyAccessor.getInstance()
-                    .getProperties(NhincConstants.DOCUMENT_TYPE_PROPERTY_FILE);
+                .getProperties(NhincConstants.DOCUMENT_TYPE_PROPERTY_FILE);
             Iterator<Entry<Object, Object>> it = localDocumentTypeProperties.entrySet().iterator();
             while (it.hasNext()) {
                 Entry<Object, Object> property = it.next();
@@ -757,12 +758,12 @@ public class PatientSearchBean {
     public StreamedContent getDocumentImage() {
         // return the content only if its an image file
         if (getSelectedCurrentDocument().getContentType() != null && (getSelectedCurrentDocument().getContentType()
-                .equals(GatewayService.CONTENT_TYPE_IMAGE_PNG)
-                || getSelectedCurrentDocument().getContentType().equals(GatewayService.CONTENT_TYPE_IMAGE_GIF)
-                || getSelectedCurrentDocument().getContentType().equals(GatewayService.CONTENT_TYPE_IMAGE_JPEG))) {
+            .equals(GatewayService.CONTENT_TYPE_IMAGE_PNG)
+            || getSelectedCurrentDocument().getContentType().equals(GatewayService.CONTENT_TYPE_IMAGE_GIF)
+            || getSelectedCurrentDocument().getContentType().equals(GatewayService.CONTENT_TYPE_IMAGE_JPEG))) {
             byte[] imageInByteArray = getSelectedCurrentDocument().getDocumentContent();
             return new DefaultStreamedContent(new ByteArrayInputStream(imageInByteArray),
-                    getSelectedCurrentDocument().getContentType());
+                getSelectedCurrentDocument().getContentType());
         }
         return null;
     }
@@ -772,9 +773,9 @@ public class PatientSearchBean {
      */
     public boolean isRenderDocumentimage() {
         return getSelectedCurrentDocument().getContentType() != null && (getSelectedCurrentDocument().getContentType()
-                .equals(GatewayService.CONTENT_TYPE_IMAGE_PNG)
-                || getSelectedCurrentDocument().getContentType().equals(GatewayService.CONTENT_TYPE_IMAGE_GIF)
-                || getSelectedCurrentDocument().getContentType().equals(GatewayService.CONTENT_TYPE_IMAGE_JPEG));
+            .equals(GatewayService.CONTENT_TYPE_IMAGE_PNG)
+            || getSelectedCurrentDocument().getContentType().equals(GatewayService.CONTENT_TYPE_IMAGE_GIF)
+            || getSelectedCurrentDocument().getContentType().equals(GatewayService.CONTENT_TYPE_IMAGE_JPEG));
     }
 
     /**
@@ -782,7 +783,7 @@ public class PatientSearchBean {
      */
     public boolean isRenderDocumentPdf() {
         return getSelectedCurrentDocument().getContentType() != null
-                && getSelectedCurrentDocument().getContentType().equals(GatewayService.CONTENT_TYPE_APPLICATION_PDF);
+            && getSelectedCurrentDocument().getContentType().equals(GatewayService.CONTENT_TYPE_APPLICATION_PDF);
     }
 
     /**
@@ -790,7 +791,7 @@ public class PatientSearchBean {
      */
     public boolean isRenderDocumentText() {
         return getSelectedCurrentDocument().getContentType() != null
-                && (getSelectedCurrentDocument().getContentType().equals(GatewayService.CONTENT_TYPE_APPLICATION_XML)
+            && (getSelectedCurrentDocument().getContentType().equals(GatewayService.CONTENT_TYPE_APPLICATION_XML)
                 || getSelectedCurrentDocument().getContentType().equals(GatewayService.CONTENT_TYPE_TEXT_HTML)
                 || getSelectedCurrentDocument().getContentType().equals(GatewayService.CONTENT_TYPE_TEXT_PLAIN)
                 || getSelectedCurrentDocument().getContentType().equals(GatewayService.CONTENT_TYPE_TEXT_XML));
@@ -802,10 +803,10 @@ public class PatientSearchBean {
     public StreamedContent getDocumentPdf() {
         // return the content only if its an pdf file
         if (getSelectedCurrentDocument().getContentType() != null
-                && getSelectedCurrentDocument().getContentType().equals(GatewayService.CONTENT_TYPE_APPLICATION_PDF)) {
+            && getSelectedCurrentDocument().getContentType().equals(GatewayService.CONTENT_TYPE_APPLICATION_PDF)) {
             byte[] imageInByteArray = getSelectedCurrentDocument().getDocumentContent();
             return new DefaultStreamedContent(new ByteArrayInputStream(imageInByteArray),
-                    getSelectedCurrentDocument().getContentType());
+                getSelectedCurrentDocument().getContentType());
         }
         return null;
     }
@@ -816,13 +817,13 @@ public class PatientSearchBean {
     public String getDocumentXml() {
         // return the content only if its an pdf file
         if (getSelectedCurrentDocument().getContentType() != null && (getSelectedCurrentDocument().getContentType()
-                .equals(GatewayService.CONTENT_TYPE_APPLICATION_XML)
-                || getSelectedCurrentDocument().getContentType().equals(GatewayService.CONTENT_TYPE_TEXT_HTML)
-                || getSelectedCurrentDocument().getContentType().equals(GatewayService.CONTENT_TYPE_TEXT_PLAIN)
-                || getSelectedCurrentDocument().getContentType().equals(GatewayService.CONTENT_TYPE_TEXT_XML))) {
-            
-            
-            return new String(getSelectedCurrentDocument().getDocumentContent());
+            .equals(GatewayService.CONTENT_TYPE_APPLICATION_XML)
+            || getSelectedCurrentDocument().getContentType().equals(GatewayService.CONTENT_TYPE_TEXT_HTML)
+            || getSelectedCurrentDocument().getContentType().equals(GatewayService.CONTENT_TYPE_TEXT_PLAIN)
+            || getSelectedCurrentDocument().getContentType().equals(GatewayService.CONTENT_TYPE_TEXT_XML))) {
+
+
+            return new String(getSelectedCurrentDocument().getHtmlContent());
         }
         return null;
     }

--- a/PDMP-Demo/src/main/java/gov/hhs/fha/nhinc/pdmp/model/Document.java
+++ b/PDMP-Demo/src/main/java/gov/hhs/fha/nhinc/pdmp/model/Document.java
@@ -65,8 +65,10 @@ public class Document {
     // unique ID from document
     private String documentId;
     private String patientId;
-
+    // raw CDA xml content
     private byte[] documentContent;
+    // CDA in html format after applying xslt
+    private byte[] htmlContent;
     private boolean documentRetrieved;
 
     private String contentType;
@@ -584,7 +586,14 @@ public class Document {
     public void setDocumentTypeName(String documentTypeName) {
         this.documentTypeName = documentTypeName;
     }
-    
-    
+
+    public byte[] getHtmlContent() {
+        return htmlContent;
+    }
+
+    public void setHtmlContent(byte[] htmlContent) {
+        this.htmlContent = htmlContent;
+    }
+
 
 }

--- a/PDMP-Demo/src/main/java/gov/hhs/fha/nhinc/pdmp/services/GatewayService.java
+++ b/PDMP-Demo/src/main/java/gov/hhs/fha/nhinc/pdmp/services/GatewayService.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009-2018, United States Government, as represented by the Secretary of Health and Human Services.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above
@@ -12,7 +12,7 @@
  *     * Neither the name of the United States Government nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -28,14 +28,7 @@ package gov.hhs.fha.nhinc.pdmp.services;
 
 import static gov.hhs.fha.nhinc.util.StreamUtils.closeStreamSilently;
 
-import gov.hhs.fha.nhinc.pdmp.managed.PatientSearchBean;
-import gov.hhs.fha.nhinc.pdmp.model.Document;
-import gov.hhs.fha.nhinc.pdmp.model.Patient;
 import gov.hhs.fha.nhinc.admingui.services.exception.DocumentMetadataException;
-import gov.hhs.fha.nhinc.pdmp.services.impl.DocumentQueryServiceImpl;
-import gov.hhs.fha.nhinc.pdmp.services.impl.DocumentRetrieveServiceImpl;
-import gov.hhs.fha.nhinc.pdmp.services.impl.PatientServiceImpl;
-import gov.hhs.fha.nhinc.pdmp.util.XSLTransformHelper;
 import gov.hhs.fha.nhinc.docquery.builder.impl.FindDocumentsAdhocQueryRequestBuilder;
 import gov.hhs.fha.nhinc.docquery.model.DocumentMetadata;
 import gov.hhs.fha.nhinc.docquery.model.DocumentMetadataResult;
@@ -44,6 +37,13 @@ import gov.hhs.fha.nhinc.docquery.model.builder.impl.DocumentMetadataResultsMode
 import gov.hhs.fha.nhinc.docretrieve.model.DocumentRetrieve;
 import gov.hhs.fha.nhinc.docretrieve.model.DocumentRetrieveResults;
 import gov.hhs.fha.nhinc.patientdiscovery.model.PatientSearchResults;
+import gov.hhs.fha.nhinc.pdmp.managed.PatientSearchBean;
+import gov.hhs.fha.nhinc.pdmp.model.Document;
+import gov.hhs.fha.nhinc.pdmp.model.Patient;
+import gov.hhs.fha.nhinc.pdmp.services.impl.DocumentQueryServiceImpl;
+import gov.hhs.fha.nhinc.pdmp.services.impl.DocumentRetrieveServiceImpl;
+import gov.hhs.fha.nhinc.pdmp.services.impl.PatientServiceImpl;
+import gov.hhs.fha.nhinc.pdmp.util.XSLTransformHelper;
 import gov.hhs.fha.nhinc.util.format.UTCDateUtil;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -203,6 +203,7 @@ public class GatewayService {
         final DocumentRetrieveResults response = documentRetrieveService.retrieveDocuments(docRetrieve);
         // set the retrieved document to the UI patient bean
         if (response.getDocument() != null) {
+            patientQuerySearch.getSelectedCurrentDocument().setDocumentContent(response.getDocument());
             if (response.getContentType() != null && (response.getContentType().equals(CONTENT_TYPE_APPLICATION_XML)
                 || response.getContentType().equals(CONTENT_TYPE_TEXT_HTML)
                 || response.getContentType().equals(CONTENT_TYPE_TEXT_PLAIN)
@@ -215,9 +216,7 @@ public class GatewayService {
                     convertXmlToHtml = transformer.convertXMLToHTML(xml, xsl);
                     closeStreamSilently(xsl);
                 }
-                patientQuerySearch.getSelectedCurrentDocument().setDocumentContent(convertXmlToHtml);
-            } else {
-                patientQuerySearch.getSelectedCurrentDocument().setDocumentContent(response.getDocument());
+                patientQuerySearch.getSelectedCurrentDocument().setHtmlContent(convertXmlToHtml);
             }
             patientQuerySearch.getSelectedCurrentDocument().setDocumentRetrieved(true);
             LOG.debug("Successfully retrieved the content of document with documentid: {}", response.getContentType());


### PR DESCRIPTION
The XHTML requires bean to have raw html content in order to display.  Therefore, we need to hold 2 byte[]: 1 for raw xml and the other for html content.  